### PR TITLE
Add Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: haskell
+
+ghc:
+  - 7.8
+
+install:
+ - cabal install happy
+ - cabal install --only-dependencies --enable-tests
+
+script:
+ - cabal configure --enable-tests
+ - cabal build --ghc-options=-Werror
+
+ # uncomment once Travis's version of Cabal knows about PatternSynonyms
+ # - cabal check
+
+ # commented out because Python tests don't want to run
+ # - cabal test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Kalium
 
+[![Build status](https://secure.travis-ci.org/int-index/kalium.svg)](http://travis-ci.org/int-index/kalium)
+
 This is a Pascal to Haskell translator. The ultimate goal is to generate
 idiomatic functional code from imperative code. The project is under heavy
 development, so nothing is documented.

--- a/kalium.cabal
+++ b/kalium.cabal
@@ -1,11 +1,20 @@
 name:                kalium
 version:             0.1.0.0
 synopsis:            A Pascal to Haskell translator.
+description:         A Pascal to Haskell translator.
+category:            Code Generation
 license:             BSD3
 license-file:        LICENSE
 author:              Index Int
+maintainer:          Index Int <vlad.z.4096@gmail.com>
+homepage:            http://int-index.github.io/kalium/
+bug-reports:         http://github.com/int-index/kalium/issues
 build-type:          Simple
 cabal-version:       >=1.18
+
+source-repository head
+  type:                git
+  location:            git://github.com/int-index/kalium.git
 
 library
   exposed-modules:     Kalium
@@ -44,7 +53,7 @@ library
                        Control.Monad.Config
                        Control.Dependent
 
-  build-depends:       base
+  build-depends:       base < 5
                ,       transformers
                ,       mtl
                ,       containers

--- a/kalium.cabal
+++ b/kalium.cabal
@@ -5,7 +5,7 @@ license:             BSD3
 license-file:        LICENSE
 author:              Index Int
 build-type:          Simple
-cabal-version:       >=1.22
+cabal-version:       >=1.18
 
 library
   exposed-modules:     Kalium

--- a/kalium.cabal
+++ b/kalium.cabal
@@ -64,7 +64,7 @@ library
                ,       haskell-src-exts == 1.16.*
                ,       parsec
 
-  ghc-options:         -W -O2
+  ghc-options:         -W
   ghc-prof-options:    -fprof-auto
   hs-source-dirs:      src
   default-language:    Haskell2010
@@ -85,7 +85,7 @@ executable kalium-tool
                ,       mtl
                ,       optparse-applicative
                ,       kalium
-  ghc-options:         -W -O2 -threaded "-with-rtsopts=-N"
+  ghc-options:         -W -threaded "-with-rtsopts=-N"
   ghc-prof-options:    -fprof-auto
   hs-source-dirs:      src/kalium-tool
   default-language:    Haskell2010

--- a/kalium.cabal
+++ b/kalium.cabal
@@ -54,7 +54,7 @@ library
                        Control.Dependent
 
   build-depends:       base < 5
-               ,       transformers
+               ,       transformers >= 0.4
                ,       mtl
                ,       containers
                ,       unordered-containers


### PR DESCRIPTION
[Travis CI](http://travis-ci.org) is a site which downloads and compiles the project after each `git push`, sends emails when build is failing, and stuff. It can also run tests, but in this case it doesn't (probably because its `python3` binary is called simply `python`, but I haven't investigated). You only need to register there, enable integration for this project, and make any commit.

Travis can also run builds using several versions of GHC. Kalium currently only builds on GHC 7.8, but when GHC 7.10 comes out, it might be nice to keep supporting both versions, and so Travis would be more useful in this situation than it is presently.

List of other changes, which might be useful when/if this package is added to Hackage:
- A lower bound on transformers (e.g. on my laptop it was choosing the wrong version until I added the bound), and an upper bound of `5` on base (just in case, and also because `cabal check` was complaining).
- `.cabal` boilerplate, such as “maintainer” field and so on.
- Removed `-O2` (since `-O` is added by Cabal by default, and `-O2` is slower but not particularly more performant; I might be wrong, of course, if the decision to have `-O2` was deliberate).
